### PR TITLE
Public updates

### DIFF
--- a/src/plot2svg.m
+++ b/src/plot2svg.m
@@ -134,6 +134,8 @@ function varargout = plot2svg(param1,id,pixelfiletype)
 %               placement
 %  19-02-2015 - Properly calculate the axes limits when the user has
 %               specified infinite limits
+%  19-02-2015 - Added bug fix for when ticks are specified outside the plot
+%               window
 
 global PLOT2SVG_globals
 global colorname
@@ -2590,6 +2592,7 @@ if strcmp(get(ax,'XTickLabelMode'),'auto') && strcmp(get(ax,'XScale'),'linear')
     numlabels = numlabels(:);
     labelpos = labelpos(:);
     indexnz = find(labelpos ~= 0);
+    indexnz(indexnz > numel(numlabels)) = [];
     if (~isempty(indexnz) && ~isempty(numlabels))
         ratio=numlabels(indexnz)./labelpos(indexnz);
         if round(log10(ratio(1))) ~= 0 && ratio(1) ~= 0
@@ -2618,6 +2621,7 @@ if strcmp(get(ax,'YTickLabelMode'),'auto') && strcmp(get(ax,'YScale'),'linear')
     numlabels = numlabels(:);
     labelpos = labelpos(:);
     indexnz = find(labelpos ~= 0);
+    indexnz(indexnz > numel(numlabels)) = [];
     if (~isempty(indexnz) && ~isempty(numlabels))
         ratio = numlabels(indexnz)./labelpos(indexnz);
         if round(log10(ratio(1))) ~= 0 && ratio(1) ~= 0
@@ -2646,6 +2650,7 @@ if strcmp(get(ax,'ZTickLabelMode'),'auto') && strcmp(get(ax,'ZScale'),'linear')
     numlabels = numlabels(:);
     labelpos = labelpos(:);
     indexnz = find(labelpos ~= 0);
+    indexnz(indexnz > numel(numlabels)) = [];
     if (~isempty(indexnz) && ~isempty(numlabels))
         ratio = numlabels(indexnz)./labelpos(indexnz);
         if round(log10(ratio(1))) ~= 0 && ratio(1) ~= 0

--- a/src/plot2svg.m
+++ b/src/plot2svg.m
@@ -136,6 +136,9 @@ function varargout = plot2svg(param1,id,pixelfiletype)
 %               specified infinite limits
 %  19-02-2015 - Added bug fix for when ticks are specified outside the plot
 %               window
+%  19-02-2015 - Bug fix for log scale minor ticks not showing above the
+%               largest power of 10. Inspired by Valentin, but used a
+%               simpler solution
 
 global PLOT2SVG_globals
 global colorname
@@ -987,7 +990,7 @@ if strcmp(get(ax,'Visible'),'on')
         axxtick = log10(get(ax,'XTick'));
         minor_axxtick = [];
         if ~isempty(axxtick)
-            all_axxtick = axxtick(1):1:axxtick(end); 
+            all_axxtick = axxtick(1):1:(axxtick(end) + 1); 
             for stick = all_axxtick
                 minor_axxtick = [minor_axxtick minor_log_sticks + stick]; 
             end
@@ -998,7 +1001,7 @@ if strcmp(get(ax,'Visible'),'on')
         axytick=log10(get(ax,'YTick'));
         minor_axytick = [];
         if ~isempty(axytick)
-            all_axytick = axytick(1):1:axytick(end); 
+            all_axytick = axytick(1):1:(axytick(end) + 1); 
             for stick = all_axytick
                 minor_axytick = [minor_axytick minor_log_sticks + stick]; 
             end
@@ -1009,7 +1012,7 @@ if strcmp(get(ax,'Visible'),'on')
         axztick=log10(get(ax,'ZTick'));
         minor_axztick = [];
         if ~isempty(axztick)
-            all_axztick = axztick(1):1:axztick(end); 
+            all_axztick = axztick(1):1:(axztick(end) + 1); 
             for stick = all_axztick
                 minor_axztick = [minor_axztick minor_log_sticks + stick]; 
             end

--- a/src/plot2svg.m
+++ b/src/plot2svg.m
@@ -130,6 +130,8 @@ function varargout = plot2svg(param1,id,pixelfiletype)
 %               opacity and colors). line2svg now supports opacity,
 %               although MATLAB does not allow ordinary line objects to
 %               have an alpha value, as far as I know
+%  19-02-2015 - Update for MATLAB 2015b: use axes OuterPosition for axes
+%               placement
 
 global PLOT2SVG_globals
 global colorname
@@ -2451,7 +2453,11 @@ end
 function control2svg(fid,id,ax,group,paperpos)
 global PLOT2SVG_globals
 set(ax,'Units','pixels');
-pos=get(ax,'Position');
+if verLessThan('matlab', '8.4.0')
+    pos=get(ax,'Position');
+else
+    pos=ax.OuterPosition;
+end
 pict=getframe(id,pos);
 if isempty(pict.colormap)
     pict.colormap=colormap;

--- a/src/plot2svg.m
+++ b/src/plot2svg.m
@@ -110,6 +110,10 @@ function varargout = plot2svg(param1,id,pixelfiletype)
 %               (thanks to Stuart Layton)
 %  30-11-2014 - Preliminary partial support for contour objects
 
+% Edits made by Jonathon Harding
+%  18-02-2015 - Removed calls to `find` inside variable indexes, as these
+%               are not necessary for MATLAB
+
 global PLOT2SVG_globals
 global colorname
 progversion='16-Feb-2013';
@@ -290,15 +294,15 @@ if PLOT2SVG_globals.checkUserData && isstruct(get(id,'UserData'))
                     clipz = clip(:, 3);
                 end
                 if strcmp(get(ax,'XScale'),'log')
-                    clipx(find(clipx<=0)) = NaN;
+                    clipx(clipx<=0) = NaN;
                     clipx=log10(clipx);
                 end
                 if strcmp(get(ax,'YScale'),'log')
-                    clipy(find(clipy<=0)) = NaN;
+                    clipy(clipy<=0) = NaN;
                     clipy=log10(clipy);
                 end
                 if strcmp(get(ax,'ZScale'),'log')
-                    clipz(find(clipz<=0)) = NaN;
+                    clipz(clipz<=0) = NaN;
                     clipz=log10(clipz);
                 end
                 [x,y,z] = project(clipx,clipy,clipz,projection);
@@ -788,15 +792,15 @@ axlimyori=axlimy;
 axlimzori=axlimz;
 if strcmp(get(ax,'XScale'),'log')
     axlimx=log10(axlimx);
-    axlimx(find(isinf(axlimx)))=0;
+    axlimx(isinf(axlimx))=0;
 end
 if strcmp(get(ax,'YScale'),'log')
     axlimy=log10(axlimy);
-    axlimy(find(isinf(axlimy)))=0;
+    axlimy(isinf(axlimy))=0;
 end
 if strcmp(get(ax,'ZScale'),'log')
     axlimz=log10(axlimz);
-    axlimz(find(isinf(axlimz)))=0;
+    axlimz(isinf(axlimz))=0;
 end
 if strcmp(get(ax,'XDir'),'reverse')
     axlimx = fliplr(axlimx);
@@ -898,7 +902,7 @@ if strcmp(get(ax,'Visible'),'on')
         for stick = [2*axxtick(1)-axxtick(2) axxtick]
             minor_axxtick = [minor_axxtick minor_lin_sticks + stick]; 
         end
-        minor_axxtick = minor_axxtick(find(minor_axxtick > min(axlimx) & minor_axxtick < max(axlimx)));
+        minor_axxtick = minor_axxtick(minor_axxtick > min(axlimx) & minor_axxtick < max(axlimx));
     else
         minor_axxtick = [];
     end
@@ -908,7 +912,7 @@ if strcmp(get(ax,'Visible'),'on')
         for stick = [2*axytick(1)-axytick(2) axytick]
             minor_axytick = [minor_axytick minor_lin_sticks + stick]; 
         end
-        minor_axytick = minor_axytick(find(minor_axytick > min(axlimy) & minor_axytick < max(axlimy)));
+        minor_axytick = minor_axytick(minor_axytick > min(axlimy) & minor_axytick < max(axlimy));
     else
         minor_axytick = [];
     end
@@ -918,7 +922,7 @@ if strcmp(get(ax,'Visible'),'on')
         for stick = [2*axztick(1)-axztick(2) axztick]
             minor_axztick = [minor_axztick minor_lin_sticks + stick]; 
         end
-        minor_axztick = minor_axztick(find(minor_axztick > min(axlimz) & minor_axztick < max(axlimz)));
+        minor_axztick = minor_axztick(minor_axztick > min(axlimz) & minor_axztick < max(axlimz));
     else
         minor_axztick = [];
     end
@@ -951,7 +955,7 @@ if strcmp(get(ax,'Visible'),'on')
                 minor_axxtick = [minor_axxtick minor_log_sticks + stick]; 
             end
         end
-        minor_axxtick = minor_axxtick(find(minor_axxtick > min(axlimx) & minor_axxtick < max(axlimx)));
+        minor_axxtick = minor_axxtick(minor_axxtick > min(axlimx) & minor_axxtick < max(axlimx));
     end
     if strcmp(get(ax,'YScale'),'log')
         axytick=log10(get(ax,'YTick'));
@@ -962,7 +966,7 @@ if strcmp(get(ax,'Visible'),'on')
                 minor_axytick = [minor_axytick minor_log_sticks + stick]; 
             end
         end
-        minor_axytick = minor_axytick(find(minor_axytick > min(axlimy) & minor_axytick < max(axlimy)));
+        minor_axytick = minor_axytick(minor_axytick > min(axlimy) & minor_axytick < max(axlimy));
     end
     if strcmp(get(ax,'ZScale'),'log')
         axztick=log10(get(ax,'ZTick'));
@@ -973,7 +977,7 @@ if strcmp(get(ax,'Visible'),'on')
                 minor_axztick = [minor_axztick minor_log_sticks + stick]; 
             end
         end
-        minor_axztick = minor_axztick(find(minor_axztick > min(axlimz) & minor_axztick < max(axlimz)));
+        minor_axztick = minor_axztick(minor_axztick > min(axlimz) & minor_axztick < max(axlimz));
     end
     % Draw back faces 
     linewidth=get(ax,'LineWidth');
@@ -1377,13 +1381,13 @@ for i=length(axchild):-1:1
         linex = get(axchild(i),'XData');
         linex = linex(:)'; % Octave stores the data in a column vector
         if strcmp(get(ax,'XScale'),'log')
-            linex(find(linex<=0)) = NaN;
+            linex(linex<=0) = NaN;
             linex=log10(linex);
         end
         liney=get(axchild(i),'YData');
         liney = liney(:)'; % Octave stores the data in a column vector        
         if strcmp(get(ax,'YScale'),'log')
-            liney(find(liney<=0)) = NaN;
+            liney(liney<=0) = NaN;
             liney=log10(liney);
         end
         linez=get(axchild(i),'ZData');
@@ -1392,7 +1396,7 @@ for i=length(axchild):-1:1
             linez = zeros(size(linex));    
         end
         if strcmp(get(ax,'ZScale'),'log')
-            linez(find(linez<=0)) = NaN;
+            linez(linez<=0) = NaN;
             linez=log10(linez);
         end
         [x,y,z] = project(linex,liney,linez,projection);
@@ -1882,12 +1886,12 @@ for i=length(axchild):-1:1
         position = get(axchild(i),'Position');
         posx = [position(1) position(1)+position(3)];
         if strcmp(get(ax,'XScale'),'log')
-            posx(find(posx <= 0)) = NaN;
+            posx(posx <= 0) = NaN;
             posx=log10(posx);
         end
         posy = [position(2) position(2)+position(4)];
         if strcmp(get(ax,'YScale'),'log')
-            posy(find(posy <= 0)) = NaN;
+            posy(posy <= 0) = NaN;
             posy=log10(posy);
         end
         posz=[0 0];
@@ -2787,7 +2791,7 @@ if ~isempty(StringText)
         fprintf(['Warning: Found a closed brace without a previously opened brace. Latex string ''' StringText ''' will not be converted.\n']);
     else
         if isempty(bracket)
-            if ~isempty(find(StringText == '^' | StringText == '_' | StringText == '\' ))
+            if any(StringText == '^' | StringText == '_' | StringText == '\' )
                 returnvalue = ['<tspan>' singleLatex2svg(StringText, size) '</tspan>'];    
                 % Clean up empty tspan elements
                 % More could be done here, but with huge effort to make it

--- a/src/plot2svg.m
+++ b/src/plot2svg.m
@@ -113,6 +113,8 @@ function varargout = plot2svg(param1,id,pixelfiletype)
 % Edits made by Jonathon Harding
 %  18-02-2015 - Removed calls to `find` inside variable indexes, as these
 %               are not necessary for MATLAB
+%  18-02-2015 - Added MException catching to try/catch blocks and the
+%               assocciated warning messages
 
 global PLOT2SVG_globals
 global colorname
@@ -593,8 +595,12 @@ if PLOT2SVG_globals.checkUserData && isstruct(get(id,'UserData'))
                         otherwise
                             error(['Unknown filter ''' filter(i).Subfilter.Type '''.']);
                     end
-                catch
-                    error([lasterr ' Error is caused by filter type ''' filter(i).Subfilter.Type '''.']);
+                catch ME
+                    errStr = ME.identifier;
+                    if isempty(errStr)
+                        errStr = ME.message;
+                    end
+                    error([errStr ' Error is caused by filter type ''' filter(i).Subfilter.Type '''.']);
                 end
             end
             fprintf(fid,'  </filter>\n');
@@ -2860,8 +2866,12 @@ if ~isempty(StringText)
         end
     end
 end
-catch
-    fprintf(['Warning: Error ''' lasterr ''' occurred during conversion. Latex string ''' StringText ''' will not be converted.\n']);
+catch ME
+    errStr = ME.identifier;
+    if isempty(errStr)
+        errStr = ME.message;
+    end
+    fprintf(['Warning: Error ''' errStr ''' occurred during conversion. Latex string ''' StringText ''' will not be converted.\n']);
 end
 
 function StringText = singleLatex2svg(StringText, size)

--- a/src/plot2svg.m
+++ b/src/plot2svg.m
@@ -1485,30 +1485,32 @@ for i=length(axchild):-1:1
         end
         line2svg(fid,groupax,axpos,x,y,scolorname,linestyle,linewidth)
         % put the markers into a subgroup of the lines
-        fprintf(fid,'<g>\n');
-        switch marker
-            case 'none';
-            case '.',group=group+1;circle2svg(fid,group,axpos,x,y,markersize*0.25,'none',markeredgecolorname,linewidth);
-            case 'o',group=group+1;circle2svg(fid,group,axpos,x,y,markersize*0.75,markeredgecolorname,markerfacecolorname,linewidth);
-            case '+',group=group+1;patch2svg(fid,group,axpos,x'*ones(1,5)+ones(length(linex),1)*[-1 1 NaN 0 0]*markersize,y'*ones(1,5)+ones(length(liney),1)*[0 0 NaN -1 1]*markersize,markeredgecolorname,'-',linewidth,markeredgecolorname, 1, 1, false);   
-            case '*',group=group+1;patch2svg(fid,group,axpos,x'*ones(1,11)+ones(length(linex),1)*[-1 1 NaN 0 0 NaN -0.7 0.7 NaN -0.7 0.7]*markersize,y'*ones(1,11)+ones(length(liney),1)*[0 0 NaN -1 1 NaN 0.7 -0.7 NaN -0.7 0.7]*markersize,markeredgecolorname,'-',linewidth,markeredgecolorname, 1, 1, false);
-            case 'x',group=group+1;patch2svg(fid,group,axpos,x'*ones(1,5)+ones(length(linex),1)*[-0.7 0.7 NaN -0.7 0.7]*markersize,y'*ones(1,5)+ones(length(liney),1)*[0.7 -0.7 NaN -0.7 0.7]*markersize,markeredgecolorname,'-',linewidth,markeredgecolorname, 1, 1, false);
-            %% Octave keeps s, d, p and h in the HandleGraphics object, for the square, diamond, pentagram, and hexagram markers, respectively -- Jakob Malm
-            case {'square', 's'},group=group+1;patch2svg(fid,group,axpos,x'*ones(1,5)+ones(length(linex),1)*[-1 -1 1 1 -1]*markersize,y'*ones(1,5)+ones(length(liney),1)*[-1 1 1 -1 -1]*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);
-            case {'diamond', 'd'},group=group+1;patch2svg(fid,group,axpos,x'*ones(1,5)+ones(length(linex),1)*[-0.7071 0 0.7071 0 -0.7071]*markersize,y'*ones(1,5)+ones(length(liney),1)*[0 1 0 -1 0]*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);
-            case {'pentagram', 'p'},group=group+1;patch2svg(fid,group,axpos,...
-                    x'*ones(1,11)+ones(length(linex),1)*[0 0.1180 0.5 0.1910 0.3090 0 -0.3090 -0.1910 -0.5 -0.1180 0]*1.3*markersize,...
-                    y'*ones(1,11)+ones(length(liney),1)*[-0.5257 -0.1625 -0.1625 0.0621 0.4253 0.2008 0.4253 0.0621 -0.1625 -0.1625 -0.5257]*1.3*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);
-            case {'hexagram', 'h'},group=group+1;patch2svg(fid,group,axpos,...
-                    x'*ones(1,13)+ones(length(linex),1)*[0 0.2309 0.6928 0.4619 0.6928 0.2309 0 -0.2309 -0.6928 -0.4619 -0.6928 -0.2309 0]*1*markersize,...
-                    y'*ones(1,13)+ones(length(liney),1)*[0.8 0.4 0.4 0 -0.4 -0.4 -0.8 -0.4 -0.4 0 0.4 0.4 0.8]*1*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);    
-            case '^',group=group+1;patch2svg(fid,group,axpos,x'*ones(1,4)+ones(length(linex),1)*[-1 1 0 -1]*markersize,y'*ones(1,4)+ones(length(liney),1)*[0.577 0.577 -1.155 0.577]*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);
-            case 'v',group=group+1;patch2svg(fid,group,axpos,x'*ones(1,4)+ones(length(linex),1)*[-1 1 0 -1]*markersize,y'*ones(1,4)+ones(length(liney),1)*[-0.577 -0.577 1.155 -0.577]*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);
-            case '<',group=group+1;patch2svg(fid,group,axpos,x'*ones(1,4)+ones(length(linex),1)*[0.577 0.577 -1.155 0.577]*markersize,y'*ones(1,4)+ones(length(liney),1)*[-1 1 0 -1]*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);
-            case '>',group=group+1;patch2svg(fid,group,axpos,x'*ones(1,4)+ones(length(linex),1)*[-0.577 -0.577 1.155 -0.577]*markersize,y'*ones(1,4)+ones(length(liney),1)*[-1 1 0 -1]*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);
+        if  ~strcmp(marker, 'none') % but only do it if we actually are drawing markers
+            fprintf(fid,'<g>\n');
+            switch marker
+                case 'none';
+                case '.',group=group+1;circle2svg(fid,group,axpos,x,y,markersize*0.25,'none',markeredgecolorname,linewidth);
+                case 'o',group=group+1;circle2svg(fid,group,axpos,x,y,markersize*0.75,markeredgecolorname,markerfacecolorname,linewidth);
+                case '+',group=group+1;patch2svg(fid,group,axpos,x'*ones(1,5)+ones(length(linex),1)*[-1 1 NaN 0 0]*markersize,y'*ones(1,5)+ones(length(liney),1)*[0 0 NaN -1 1]*markersize,markeredgecolorname,'-',linewidth,markeredgecolorname, 1, 1, false);   
+                case '*',group=group+1;patch2svg(fid,group,axpos,x'*ones(1,11)+ones(length(linex),1)*[-1 1 NaN 0 0 NaN -0.7 0.7 NaN -0.7 0.7]*markersize,y'*ones(1,11)+ones(length(liney),1)*[0 0 NaN -1 1 NaN 0.7 -0.7 NaN -0.7 0.7]*markersize,markeredgecolorname,'-',linewidth,markeredgecolorname, 1, 1, false);
+                case 'x',group=group+1;patch2svg(fid,group,axpos,x'*ones(1,5)+ones(length(linex),1)*[-0.7 0.7 NaN -0.7 0.7]*markersize,y'*ones(1,5)+ones(length(liney),1)*[0.7 -0.7 NaN -0.7 0.7]*markersize,markeredgecolorname,'-',linewidth,markeredgecolorname, 1, 1, false);
+                %% Octave keeps s, d, p and h in the HandleGraphics object, for the square, diamond, pentagram, and hexagram markers, respectively -- Jakob Malm
+                case {'square', 's'},group=group+1;patch2svg(fid,group,axpos,x'*ones(1,5)+ones(length(linex),1)*[-1 -1 1 1 -1]*markersize,y'*ones(1,5)+ones(length(liney),1)*[-1 1 1 -1 -1]*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);
+                case {'diamond', 'd'},group=group+1;patch2svg(fid,group,axpos,x'*ones(1,5)+ones(length(linex),1)*[-0.7071 0 0.7071 0 -0.7071]*markersize,y'*ones(1,5)+ones(length(liney),1)*[0 1 0 -1 0]*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);
+                case {'pentagram', 'p'},group=group+1;patch2svg(fid,group,axpos,...
+                        x'*ones(1,11)+ones(length(linex),1)*[0 0.1180 0.5 0.1910 0.3090 0 -0.3090 -0.1910 -0.5 -0.1180 0]*1.3*markersize,...
+                        y'*ones(1,11)+ones(length(liney),1)*[-0.5257 -0.1625 -0.1625 0.0621 0.4253 0.2008 0.4253 0.0621 -0.1625 -0.1625 -0.5257]*1.3*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);
+                case {'hexagram', 'h'},group=group+1;patch2svg(fid,group,axpos,...
+                        x'*ones(1,13)+ones(length(linex),1)*[0 0.2309 0.6928 0.4619 0.6928 0.2309 0 -0.2309 -0.6928 -0.4619 -0.6928 -0.2309 0]*1*markersize,...
+                        y'*ones(1,13)+ones(length(liney),1)*[0.8 0.4 0.4 0 -0.4 -0.4 -0.8 -0.4 -0.4 0 0.4 0.4 0.8]*1*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);    
+                case '^',group=group+1;patch2svg(fid,group,axpos,x'*ones(1,4)+ones(length(linex),1)*[-1 1 0 -1]*markersize,y'*ones(1,4)+ones(length(liney),1)*[0.577 0.577 -1.155 0.577]*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);
+                case 'v',group=group+1;patch2svg(fid,group,axpos,x'*ones(1,4)+ones(length(linex),1)*[-1 1 0 -1]*markersize,y'*ones(1,4)+ones(length(liney),1)*[-0.577 -0.577 1.155 -0.577]*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);
+                case '<',group=group+1;patch2svg(fid,group,axpos,x'*ones(1,4)+ones(length(linex),1)*[0.577 0.577 -1.155 0.577]*markersize,y'*ones(1,4)+ones(length(liney),1)*[-1 1 0 -1]*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);
+                case '>',group=group+1;patch2svg(fid,group,axpos,x'*ones(1,4)+ones(length(linex),1)*[-0.577 -0.577 1.155 -0.577]*markersize,y'*ones(1,4)+ones(length(liney),1)*[-1 1 0 -1]*markersize,markerfacecolorname,'-',linewidth,markeredgecolorname, 1, 1, true);
+            end
+            % close the marker group
+            fprintf(fid,'</g>\n');
         end
-        % close the marker group
-        fprintf(fid,'</g>\n');
         animation2svg(fid, axchild(i));
         % close the line group
         fprintf(fid,'</g>\n');


### PR DESCRIPTION
Hi Jürg,
Thanks so much for this MATLAB function, I've used it extensively throughout my PhD for making high quality graphs.
I've run into a number of bugs over the years with it, and have ended up with a collection of my own fixes for them. I've attempted to go through and apply them to your most recent version of this function, the results of which are included below. Please feel free to pull these from my fork, although I cannot promise that they are entirely bug free. I don't have and don't use Octave, so I have not checked if any of these changes cause problems in Octave.
Particularly big fixes are:
* convertunit now always respects the difference between MATLAB pixels and SVG pixels. Running MATLAB with a non-standard DPI should result in figures lines and text of the correct size.
* Text super- and subscripts use the SVG "baseline-shift" property and relative sizes. This makes the result more consistent with how Inkscape generates super- and subscripts, allowing in place editing later
* Axes limits specified as "inf" or "-inf" do not break. I added a function to check every child object with position data for their intrinsic limits
* MATLAB 2014b grid styles are now supported, including transparency and custom colors.
I have not yet fully fixed this function for 2014b (notably, legends and all annotations are ignored). I have ideas how to fix these problems, but may or may not have the time/energy to do so anytime soon.
Cheers,
Jonathon Harding