### PR TITLE
Misc additions and improvemetns for Inkscape => PDF+LaTeX workflow

### DIFF
--- a/example/demo_3d_plot2svg.m
+++ b/example/demo_3d_plot2svg.m
@@ -1,3 +1,5 @@
+%% 3D sphere with alpha data
+clear all;
 figure
 [x y z] = sphere(20); 
 s = surface(x,y,z,'facecolor','interp','cdata',z);
@@ -12,3 +14,38 @@ ylabel('Y');
 zlabel('Z');
 title('Sphere with Alpha Data');
 plot2svg('sphere.svg');
+
+%% Rescaling patches to avoid gaps
+clear all;
+
+x = -3.5:0.1:3.5;
+y = -3.5:0.1:3.5;
+
+[X, Y] = meshgrid(x, y);
+
+Z = peaks(X, Y);
+
+figure(1); 
+clf;
+surf(X, Y, Z);
+axis tight;
+xlabel('x');
+ylabel('y');
+zlabel('z');
+shading flat;
+view([20, 80]);
+
+% When exporting 3D plots with flat shading (no mesh lines around the
+% patches) some viewers show small gaps between the patches. This can even
+% lead to a mind of "semi transparent" appearance with many small patches,
+% because the background can be seen in the gaps.
+setting.svg.PatchRescale = 1;   % This is the deault setting.
+set(gcf, 'UserData', setting);
+plot2svg('flat_default.svg');
+
+% A simple solution to this problem is to tell plot2svg to slightly
+% increase the patch size, such that the patches overlap. A rescaling value
+% of 105% is usually a good value to start with.
+setting.svg.PatchRescale = 1.05;
+set(gcf, 'UserData', setting);
+plot2svg('flat_rescaled.svg');

--- a/example/demo_misc.m
+++ b/example/demo_misc.m
@@ -1,0 +1,89 @@
+%% Image overlay and typical usage.
+% The purpose of the OverlayImage function is to replace parts of a figure,
+% e.g., a rendering which is too complex to be stored as vector graphics,
+% with a bitmap image. The bitmap file is linked and not embedded in the SVG.
+
+clear all;
+
+% First, render the 3D graphics into a bitmap file.
+x = -3.5:0.1:3.5;
+y = -3.5:0.1:3.5;
+
+[X, Y] = meshgrid(x, y);
+
+Z = peaks(X, Y);
+
+figure(1); 
+clf;
+surf(X, Y, Z);
+axis tight;
+xlabel('x');
+ylabel('y');
+zlabel('z');
+shading interp;
+lighting('phong');
+camlight('headlight');
+colormap(jet(512));
+axis off;
+xl = xlim();
+yl = ylim();
+zl = zlim();
+
+bg = get(gcf, 'color');
+% Make sure the background color is saved, so that we can set it transparent
+% later.
+set(gcf, 'InvertHardCopy', 'off');
+
+print -dpng -r300 'render.png'
+
+% Load and re-save the image with transparent background.
+% Be careful that the background color doesn't occur in your plot. If this
+% is the case you should set another background color above.
+A = imread('render.png');
+imwrite(A, 'render_t.png', 'png', 'transparency', bg);
+
+% Now recreate the same axis without the data.
+% Please note:
+% In some cases it can be difficult to achieve a correct alignment of the
+% bitmap and vector output. It may require some fiddling and your mileage
+% may vary.
+figure(2); 
+clf;
+surf([0, 0;0, 0], [0, 0;0, 0], [0, 0;0, 0]);
+axis tight;
+xlabel('x');
+ylabel('y');
+zlabel('z');
+xlim(xl);
+ylim(yl);
+zlim(zl);
+
+% Last step: Store axis plot as SVG image and use the rendered data as
+% overlay.
+setting.svg.OverlayImage = 'render_t.png';
+setting.svg.OverlayImagePos = [0, 0, 1, 1];
+set(gcf, 'UserData', setting);
+
+plot2svg('overlay.svg');
+
+%% Simple use case:
+% Of course, you can use the overlay function to just add a bitmap to your
+% SVG file.
+clear all;
+
+x = 0:0.1:5;
+y = 1 + x.^2;
+
+figure(3);
+clf;
+
+plot(x, y);
+xlabel('x values');
+ylabel('y values');
+
+setting.svg.OverlayImage = 'water_stones.jpg';
+setting.svg.OverlayImagePos = [0.2, 0.2, 0.25, 0.25];
+set(gcf, 'UserData', setting);
+
+plot2svg('overlay_simple.svg');
+

--- a/example/inkscape_latex/inkscape_demo.tex
+++ b/example/inkscape_latex/inkscape_demo.tex
@@ -1,0 +1,28 @@
+\documentclass[a4paper]{article}
+\usepackage{graphicx}
+%\usepackage{showframe}
+\usepackage{geometry}
+\usepackage{color}
+\usepackage{subfig}
+
+\geometry{a4paper, portrait, left=1.5cm, right=1.5cm, top=1.5cm, bottom=1.5cm, includefoot, includehead}
+
+\newcommand{\includesvg}[1]{\input{#1.pdf_tex}}
+\newcommand{\includesvgfn}[1]{\footnotesize\input{#1.pdf_tex}}
+
+\begin{document}
+\pagestyle{empty}
+\begin{figure}
+	\centering
+	\includesvg{demo_graphics}
+	\caption{Demo for including graphics using \texttt{plot2svg} and \texttt{inkscape}.}
+\end{figure}
+
+\begin{figure}
+	\centering
+	\hfill\subfloat[Smaller graphics with default font size.]{\includesvg{demo_graphics_smaller}}\hfill\hfill
+	\subfloat[Smaller graphics with smaller font size.]{\includesvgfn{demo_graphics_smaller}}\hspace*{\fill}
+	\caption{Since all \LaTeX{} code is overlaid during the document compile pass, the font size can be set in the main document.}
+\end{figure}
+
+\end{document}

--- a/example/inkscape_latex/tutorial_inkscape.m
+++ b/example/inkscape_latex/tutorial_inkscape.m
@@ -1,0 +1,48 @@
+clear all;
+%%
+
+% Generate a nice plot.
+dt = 0.01;
+tend = 10;
+t = 0:dt:tend;
+
+y = sin(2*pi*t);
+
+figure(1);
+clf;
+plot(t, y);
+grid on;
+axis tight;
+xlabel('$t$ / s');
+ylabel('$y$ / V');
+set(gca, 'XScale', 'log');
+
+text(0.02, -0.25, '\LaTeX{} test $\frac{a}{b}$');
+legend('$\sin(2\pi t)$');
+
+% We want to use the LaTeX + PDF export capability of Inkscape. Therefore,
+% we have to make sure that plot2svg preserves all our LaTeX strings.
+% This can be achieved by setting the option LatexPassOn to true.
+setting.svg.LatexPassOn = true;
+set(gcf, 'UserData', setting);
+
+plot2svg('demo_graphics.svg');
+
+% Call Inkscape to convert the SVG file to a PDF and a LaTeX overlay file.
+% Note: This works only if the path to the Inkscape executable is correctly
+%       set up. Alternatively you could do this manually in Inkscape.
+system('inkscape -z --export-area-page --file=demo_graphics.svg --export-pdf=demo_graphics.pdf --export-latex');
+
+%%
+% Sometimes, we want the graphics to be smaller. There are multiple ways to
+% achieve this. If we want to scale everything, including the line widths,
+% the GlobalSize option can be used.
+setting.svg.GlobalScale = 0.6;
+set(gcf, 'UserData', setting);
+plot2svg('demo_graphics_smaller.svg');
+system('inkscape -z --export-area-page --file=demo_graphics_smaller.svg --export-pdf=demo_graphics_smaller.pdf --export-latex');
+
+%%
+% Call pdflatex to compile the document. Again, this only works if the
+% path to pdflatex is set up.
+system('pdflatex inkscape_demo.tex');

--- a/src/plot2svg.m
+++ b/src/plot2svg.m
@@ -148,6 +148,7 @@ function varargout = plot2svg(param1,id,pixelfiletype)
 %  14-05-2015 - Removed undefined variable which was obsolete
 % Edit by Thomas Wiesner
 %  04-07-2015 - Merge of LatexPassOn option.
+%  04-07-2015 - Merge of GlobalScale option.
 
 
 global PLOT2SVG_globals
@@ -156,6 +157,7 @@ progversion='14-May-2015';
 PLOT2SVG_globals.runningIdNumber = 0;
 PLOT2SVG_globals.octave = false;
 PLOT2SVG_globals.LatexPassOn = false;
+PLOT2SVG_globals.GlobalScale = 1;
 PLOT2SVG_globals.checkUserData = true;
 PLOT2SVG_globals.ScreenPixelsPerInch = 90; % Default 90ppi
 try
@@ -253,6 +255,9 @@ if PLOT2SVG_globals.checkUserData && isstruct(get(id,'UserData'))
         if isfield(struct_data.svg,'LatexPassOn')
             PLOT2SVG_globals.LatexPassOn = struct_data.svg.LatexPassOn;
         end
+        if isfield(struct_data.svg,'GlobalScale')
+            PLOT2SVG_globals.GlobalScale = struct_data.svg.GlobalScale;
+        end
     end
 end
 
@@ -265,13 +270,17 @@ PLOT2SVG_globals.basefilename = name;
 PLOT2SVG_globals.figurenumber = 1;
 fid=fopen(finalname,'wt');   % Create a new text file
 fprintf(fid,'<?xml version="1.0" encoding="utf-8" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n');    % Insert file header
-fprintf(fid,'<svg preserveAspectRatio="xMinYMin meet" width="100%%" height="100%%" viewBox="0 0 %0.3f %0.3f" ',paperpos(3),paperpos(4));
+fprintf(fid,'<svg preserveAspectRatio="xMinYMin meet" width="100%%" height="100%%" viewBox="0 0 %0.3f %0.3f" ',paperpos(3)*PLOT2SVG_globals.GlobalScale,paperpos(4)*PLOT2SVG_globals.GlobalScale);
 fprintf(fid,' version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"');
 %fprintf(fid,' onload="Init(evt)"');
 fprintf(fid,'>\n');
 fprintf(fid,'  <desc>Matlab Figure Converted by PLOT2SVG written by Juerg Schwizer</desc>\n');
 %fprintf(fid,'  <script type="text/ecmascript" xlink:href="puzzle_script.js" />\n');
-fprintf(fid,'  <g id="topgroup">\n');
+if PLOT2SVG_globals.GlobalScale == 1
+    fprintf(fid,'  <g id="topgroup">\n');
+else
+    fprintf(fid,'  <g id="topgroup" transform="scale(%f)">\n', PLOT2SVG_globals.GlobalScale);
+end
 group=1;
 groups=[];
 % Frame of figure

--- a/src/plot2svg.m
+++ b/src/plot2svg.m
@@ -149,6 +149,15 @@ function varargout = plot2svg(param1,id,pixelfiletype)
 % Edit by Thomas Wiesner
 %  04-07-2015 - Merge of LatexPassOn option.
 %  04-07-2015 - Merge of GlobalScale option.
+%  04-07-2015 - Merge of overlay image function.
+%               A pixel image can now be placed on top of the plot using
+%               OverlayImage. This is useful, if you want to export some
+%               parts of the plot as pixel data (e.g. for 3D surface plots
+%               which can be extremely time consuming to export as vector
+%               graphics.)
+%               The relative position of the overlay image must be set with
+%               OverlayImagePos = [x, y, width, height].
+
 
 
 global PLOT2SVG_globals
@@ -158,6 +167,8 @@ PLOT2SVG_globals.runningIdNumber = 0;
 PLOT2SVG_globals.octave = false;
 PLOT2SVG_globals.LatexPassOn = false;
 PLOT2SVG_globals.GlobalScale = 1;
+PLOT2SVG_globals.OverlayImage = '';
+PLOT2SVG_globals.OverlayImagePos = [0, 0, 1, 1];
 PLOT2SVG_globals.checkUserData = true;
 PLOT2SVG_globals.ScreenPixelsPerInch = 90; % Default 90ppi
 try
@@ -258,6 +269,17 @@ if PLOT2SVG_globals.checkUserData && isstruct(get(id,'UserData'))
         if isfield(struct_data.svg,'GlobalScale')
             PLOT2SVG_globals.GlobalScale = struct_data.svg.GlobalScale;
         end
+        if isfield(struct_data.svg,'OverlayImage')
+            PLOT2SVG_globals.OverlayImage = struct_data.svg.OverlayImage;
+            
+            if ~isfield(struct_data.svg,'OverlayImagePos')
+                disp('   Warning: OverlayImage option and no OverlayImagePos given.');
+                disp('            Image will be scaled across whole plot.');
+            end
+        end
+        if isfield(struct_data.svg,'OverlayImagePos')
+            PLOT2SVG_globals.OverlayImagePos = struct_data.svg.OverlayImagePos;
+        end
     end
 end
 
@@ -318,6 +340,10 @@ for j=length(ax):-1:1
     else
         disp(['   Warning: Unhandled main figure child type: ' currenttype]);
     end
+end
+if ~isempty(PLOT2SVG_globals.OverlayImage)
+    oip = PLOT2SVG_globals.OverlayImagePos;
+    fprintf(fid,'  <image x="%0.3f" y="%0.3f" width="%0.3f" height="%0.3f" image-rendering="optimizeSpeed" preserveAspectRatio="none" xlink:href="%s" />\n',paperpos(3)*oip(1),paperpos(4)*oip(2),paperpos(3)*oip(3),paperpos(4)*oip(4), PLOT2SVG_globals.OverlayImage);
 end
 fprintf(fid,'  </g>\n');
 fprintf(fid,'</svg>\n');


### PR DESCRIPTION
I've made some changes which improve at least my work flow and I'd like to share.
The new LatexPassOn option allows LaTeX code to be retained in the SVG file. In combination with with the Inkscape => PDF+LaTeX export, plots with native LaTeX (and LaTeX font) rendering can be achieved.
A new GlobalScale option allows global scaling of the SVG output including all line widths (Same effect as if the resulting SVG is scaled i.e. in Inkscape).
An overlay bitmap image can now be placed onto the plot which can be used to generated complex hybrid bitmap/vector graphics.
Last but not least it is possible to rescale the patches, of e.g. surface plots. This is necessary with flat shading to prevent gaps between the individual patches.

I've included examples for each of the new functions and split them up into separate commits.
